### PR TITLE
Don't add port to url if HTTP_HOST has a specified port

### DIFF
--- a/src/Http/Url/Url.php
+++ b/src/Http/Url/Url.php
@@ -108,7 +108,12 @@ class Url {
 		if ($isSslEnabled) {
 			$protocol .= 's';
 		}
-		$port = ':' . $serverArray['SERVER_PORT'];
+		preg_match('/:(\d+)$/', $serverArray['HTTP_HOST'], $portPosition);
+		if (! empty($portPosition[0])) {
+			$port = '';
+		} else {
+			$port = ':' . $serverArray['SERVER_PORT'];
+		}
 		$isHttpRequest = (! $isSslEnabled && $port == '80');
 		$isHttpsRequest = ($isSslEnabled && $port == '443');
 		if ($isHttpRequest || $isHttpsRequest) {


### PR DESCRIPTION
Under some circumstances the Url class adds the default port for
HTTP(S), even if the request url has a specified port different
from the standard HTTP(S) port.
Hitherto don't add the default port if a different port is specified
in the request.