### PR TITLE
Fix template of application kernel

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -110,7 +110,7 @@ vendor/bin/zeus c:b Test
 Next, register the bundle, which we named "Test" in your Applications Kernel 
 (in this case bundles/Application/DemoKernel.php)
 ```php
-	protected function registerBundles() {
+	protected function registerBundles(HttpRequestInterface $request) {
 		$bundles = array();
 		$bundles[] = new DemoApplicationBundle();
 		$bundles[] = new \Simovative\Demo\Test\TestBundle();

--- a/src/Console/SkeletonBuilder/Templates/application/Kernel.php.tpl
+++ b/src/Console/SkeletonBuilder/Templates/application/Kernel.php.tpl
@@ -18,7 +18,7 @@ class {{prefix}}Kernel extends HttpKernel {
 	/**
 	 * @inheritdoc
 	 */
-	protected function registerBundles() {
+	protected function registerBundles(HttpRequestInterface $request) {
 		$bundles = array();
 		$bundles[] = new {{appPrefix}}Bundle();
 		return $bundles;


### PR DESCRIPTION
According to the Readme.md you have to invoke the registerBundles()
method without any parameter. But due to commit 89d9ab13c4 that changed
and registerBundles() expects the request as a parameter now. Henceforth fix
the template for creating the application skeleton with the zeus CLI tool.
Further reflect this change in Readme.md .