### PR TITLE
- don't force assoc decoding, because we need this for opis validator

### DIFF
--- a/src/Http/HttpRequestFactory.php
+++ b/src/Http/HttpRequestFactory.php
@@ -76,7 +76,7 @@ class HttpRequestFactory extends Factory {
 			$streamContents = $parsedBody->getContents();
 			$parsedBody = $this->getMasterFactory()->createJsonEncodingService()->decode(
 				$streamContents,
-				true
+				false
 			);
 		}
 		return $parsedBody;

--- a/src/Http/Json/JsonEncodingService.php
+++ b/src/Http/Json/JsonEncodingService.php
@@ -11,7 +11,7 @@ use function json_decode;
  */
 final class JsonEncodingService implements JsonEncodingServiceInterface {
 
-	private const DEFAULT_OPTIONS = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_PARTIAL_OUTPUT_ON_ERROR;
+	private const DEFAULT_OPTIONS = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_PARTIAL_OUTPUT_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE;
 	private const DEFAULT_DEPTH = 512;
 	
 	/**


### PR DESCRIPTION
- pretty print json, because it looks better in swagger documentation
- dont encode unicode chars in json

ACFIVE-27888