### PR TITLE
ACFIVE-35323

### DIFF
--- a/src/Exception/RequestMethodNotAllowedException.php
+++ b/src/Exception/RequestMethodNotAllowedException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Simovative\Zeus\Exception;
+
+class RequestMethodNotAllowedException extends \Exception
+{
+    public function __construct()
+    {
+        parent::__construct('request method not allowed.', 405);
+    }
+}

--- a/src/Http/HttpRequestFactory.php
+++ b/src/Http/HttpRequestFactory.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Simovative\Zeus\Http;
 
-use LogicException;
 use Simovative\Zeus\Dependency\Factory;
+use Simovative\Zeus\Exception\RequestMethodNotAllowedException;
 use Simovative\Zeus\Http\Get\HttpGetRequest;
 use Simovative\Zeus\Http\Post\HttpPostRequest;
 use Simovative\Zeus\Http\Post\UploadedFile;
@@ -25,7 +25,7 @@ class HttpRequestFactory extends Factory {
 	/**
 	 * @author Benedikt Schaller
 	 * @return HttpRequestInterface
-	 * @throws LogicException
+	 * @throws RequestMethodNotAllowedException
 	 * @throws Json\JsonEncodingException
 	 */
 	public function createRequestFromGlobals() {
@@ -48,7 +48,7 @@ class HttpRequestFactory extends Factory {
 				return new HttpHeadRequest($currentUrl, $_REQUEST, $_SERVER, $parsedBody);
 		}
 		
-		throw new LogicException('request method not allowed.');
+		throw new RequestMethodNotAllowedException();
 	}
 	
 	/**

--- a/src/Http/Request/HttpRequestDispatcherLocator.php
+++ b/src/Http/Request/HttpRequestDispatcherLocator.php
@@ -2,8 +2,8 @@
 
 namespace Simovative\Zeus\Http\Request;
 
-use LogicException;
 use Simovative\Zeus\Dependency\FrameworkFactory;
+use Simovative\Zeus\Exception\RequestMethodNotAllowedException;
 use Simovative\Zeus\Http\Routing\RouteInterface;
 
 /**
@@ -38,6 +38,6 @@ class HttpRequestDispatcherLocator implements HttpRequestDispatcherLocatorInterf
             return $this->frameworkFactory->createHandlerDispatcher();
         }
 
-        throw new LogicException('request method not allowed.');
+        throw new RequestMethodNotAllowedException();
     }
 }


### PR DESCRIPTION
throw requestMethodNotAllowedException (BC BREAK) in order to properly handle invalid request methods provided from the client